### PR TITLE
Stripping symbols tables reduced binary sizes a lot

### DIFF
--- a/binary-bloat/alpine/Dockerfile
+++ b/binary-bloat/alpine/Dockerfile
@@ -3,8 +3,8 @@ RUN apk add --no-cache musl-dev gcc python3 python3-dev libffi-dev libcap-dev ma
 
 COPY hello-world.c /hello-world.c
 
-RUN gcc  /hello-world.c -O3 -static -o /hello-world-static
+RUN gcc  /hello-world.c -s -O3 -static -o /hello-world-static
 RUN du -sh /hello-world-static
 
-RUN gcc -o /hello-world /hello-world.c -O3
+RUN gcc -o /hello-world /hello-world.c -s -O3
 RUN du -sh /hello-world

--- a/binary-bloat/wolfi/Dockerfile
+++ b/binary-bloat/wolfi/Dockerfile
@@ -3,8 +3,9 @@ RUN apk add --no-cache gcc python3 python3-dev bash py3-pip glibc glibc-dev
 
 COPY hello-world.c /hello-world.c
 
-RUN gcc  /hello-world.c -O3 -static -o /hello-world-static
+RUN gcc /hello-world.c -s -O3 -static -o /hello-world-static
 RUN du -sh /hello-world-static
 
-RUN gcc -o /hello-world /hello-world.c -O3
+RUN gcc -o /hello-world /hello-world.c -s -O3
 RUN du -sh /hello-world
+


### PR DESCRIPTION
But i don't know if you care to be building binaries with symbols tables or not.

892/132 becomes 636/28.

But this might be in the realm of optimisations.